### PR TITLE
Added color profile for tilix terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Install using Atom's package manager
 ### GNOME Terminal
 * [This repo's directory](https://github.com/NLKNguyen/papercolor/tree/master/gnome-terminal)
 
+### Tilix Terminal
+* [This repo's directory](https://github.com/NLKNguyen/papercolor/tree/master/tilix)
+
 ### Base16 schemes
 * [This repo's directory](https://github.com/NLKNguyen/papercolor/tree/master/base16-builder-schemes) 
 

--- a/tilix/README.md
+++ b/tilix/README.md
@@ -1,0 +1,10 @@
+# PaperColor for Tilix
+
+## Installation
+Copy the .json file to:
+
+    ~/.config/tilix/schemes/
+
+Restart tilix and select the theme at Preferences -> Profiles -> Default -> Color -> Color scheme.
+
+Have fun!

--- a/tilix/papercolor-light.json
+++ b/tilix/papercolor-light.json
@@ -1,0 +1,33 @@
+{
+    "name": "Papercolor light",
+    "comment": "",
+    "foreground-color": "#4d4d4c",
+    "background-color": "#f3f3f3",
+    "use-theme-colors": false,
+    "use-highlight-color": false,
+    "highlight-foreground-color": "#ffffff",
+    "highlight-background-color": "#a348b1",
+    "use-cursor-color": false,
+    "cursor-foreground-color": "#ffffff",
+    "cursor-background-color": "#efefef",
+    "use-badge-color": true,
+    "badge-color": "#4d4d4c",
+    "palette": [
+        "#f3f3f3",
+        "#8959a8",
+        "#718c00",
+        "#4271ae",
+        "#005f87",
+        "#d7005f",
+        "#3e999f",
+        "#d0d0d0",
+        "#808080",
+        "#8959a8",
+        "#718c00",
+        "#4271ae",
+        "#005f87",
+        "#d7005f",
+        "#3e999f",
+        "#262626"
+    ]
+}


### PR DESCRIPTION
An initial version of the papercolor theme for tilix has been added.

The following parameter have not been edited to match them to the other colors, they have been simply copied from [this example](https://gnunn1.github.io/tilix-web/manual/themes/):
*  highlight-foreground-color
*  highlight-background-color
*  cursor-foreground-color
*  cursor-background-color

The badge color has been copied from the "gnome-terminal" light theme parameter "bold_color".